### PR TITLE
Fix date/datetime decoding error during typecast

### DIFF
--- a/adsdb.py
+++ b/adsdb.py
@@ -715,6 +715,8 @@ def ads_typecast_timestamp(s):
     if not s: return None
     if isinstance(s, datetime.datetime):
         return s
+    if isinstance(s, bytes):
+        s = s.decode('utf-8')
     if not ' ' in s: return typecast_date(s)
 
     d, t, ampm = s.split()
@@ -744,6 +746,8 @@ def ads_typecast_date(s):
     if not s: return None
     if isinstance(s, datetime.date):
         return s
+    if isinstance(s, bytes):
+        s = s.decode('utf-8')
 
     m, d, y = s.split('/')
     return s and datetime.date(int(y), int(m),


### PR DESCRIPTION
Deserializing data types to `datetime.datetime` and `datetime.date` raised `TypeError: a bytes-like object is required, not 'str'` for me with Python 3.x – adding the proper decoding fixed the issue.

Other data types might also have this issue; but don't have a table with the according columns.

Also thanks for this repo.